### PR TITLE
Fix Swift 5 beta error about not being able to express tuple conversion

### DIFF
--- a/Incremental/Incremental.swift
+++ b/Incremental/Incremental.swift
@@ -8,12 +8,11 @@ final class Queue {
     var processing: Bool = false
     
     func enqueue<S: Sequence>(_ edges: S) where S.Element: Edge {
-        self.edges.append(contentsOf: edges.map { ($0, $0.height) })
-        self.edges.sort { $0.1 < $1.1 }
+        enqueue(edges.lazy.map { $0 as Edge })
     }
     
     func enqueue<S: Sequence>(_ edges: S) where S.Element == Edge {
-        self.edges.append(contentsOf: edges.map { ($0, $0.height) })
+        self.edges.append(contentsOf: edges.lazy.map { ($0, $0.height) })
         self.edges.sort { $0.1 < $1.1 }
     }
     


### PR DESCRIPTION
Seems that Swift doesn't do tuple conversions like this (from S.Element to the existential Edge) anymore (or it never did correctly perhaps). This could also have been fixed by just changing the first `$0` to `$0 as Edge`.